### PR TITLE
Require API key and handle server errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ uv sync
 POLYGON_API_KEY=your_api_key_here uv run mcp_polygon
 ```
 
+The server will exit with an error if `POLYGON_API_KEY` is not set.
+
 <details>
   <summary>Local Dev Config for claude_desktop_config.json</summary>
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -4,9 +4,9 @@ from mcp_polygon import server
 
 # Ensure the server process doesn't exit immediately when run as an MCP server
 def start_server():
-    polygon_api_key = os.environ.get("POLYGON_API_KEY", "")
+    polygon_api_key = os.environ.get("POLYGON_API_KEY")
     if not polygon_api_key:
-        print("Warning: POLYGON_API_KEY environment variable not set.")
+        raise EnvironmentError("POLYGON_API_KEY environment variable not set.")
     else:
         print("Starting Polygon MCP server with API key configured.")
 

--- a/src/mcp_polygon/server.py
+++ b/src/mcp_polygon/server.py
@@ -6,9 +6,9 @@ from polygon import RESTClient
 
 from datetime import datetime, date
 
-POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY", "")
+POLYGON_API_KEY = os.environ.get("POLYGON_API_KEY")
 if not POLYGON_API_KEY:
-    print("Warning: POLYGON_API_KEY environment variable not set.")
+    raise EnvironmentError("POLYGON_API_KEY environment variable not set.")
 
 polygon_client = RESTClient(POLYGON_API_KEY)
 
@@ -794,4 +794,13 @@ async def list_stock_financials(
 
 def run():
     """Run the Polygon MCP server."""
-    poly_mcp.run()
+    try:
+        poly_mcp.run()
+    except Exception as exc:
+        print(f"Error running Polygon MCP server: {exc}")
+        raise
+    finally:
+        try:
+            polygon_client.close()
+        except Exception as close_exc:
+            print(f"Error closing Polygon REST client: {close_exc}")


### PR DESCRIPTION
## Summary
- enforce `POLYGON_API_KEY` in `server` and `entrypoint`
- add basic error handling and cleanup in `run`
- document failure when API key is missing

## Testing
- `python -m py_compile entrypoint.py src/mcp_polygon/server.py`
