### PR TITLE
Set a default limit

### DIFF
--- a/src/mcp_polygon/server.py
+++ b/src/mcp_polygon/server.py
@@ -33,7 +33,7 @@ async def get_aggs(
     to: Union[str, int, datetime, date],
     adjusted: Optional[bool] = None,
     sort: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -69,7 +69,7 @@ async def list_aggs(
     to: Union[str, int, datetime, date],
     adjusted: Optional[bool] = None,
     sort: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -173,7 +173,7 @@ async def list_trades(
     timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
     timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
     timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -247,7 +247,7 @@ async def list_quotes(
     timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
     timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
     timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -345,7 +345,7 @@ async def list_universal_snapshots(
     type: str,
     ticker_any_of: Optional[List[str]] = None,
     order: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -526,7 +526,7 @@ async def list_tickers(
     active: Optional[bool] = None,
     sort: Optional[str] = None,
     order: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -580,7 +580,7 @@ async def get_ticker_details(
 async def list_ticker_news(
     ticker: Optional[str] = None,
     published_utc: Optional[Union[str, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -630,7 +630,7 @@ async def list_splits(
     ticker: Optional[str] = None,
     execution_date: Optional[Union[str, datetime, date]] = None,
     reverse_split: Optional[bool] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -658,7 +658,7 @@ async def list_dividends(
     ex_dividend_date: Optional[Union[str, datetime, date]] = None,
     frequency: Optional[int] = None,
     dividend_type: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -747,7 +747,7 @@ async def list_stock_financials(
     period_of_report_date_gte: Optional[Union[str, datetime, date]] = None,
     timeframe: Optional[str] = None,
     include_sources: Optional[bool] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -796,7 +796,7 @@ async def list_ipos(
     listing_date_gt: Optional[Union[str, datetime, date]] = None,
     listing_date_gte: Optional[Union[str, datetime, date]] = None,
     ipo_status: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -834,7 +834,7 @@ async def list_short_interest(
     settlement_date_lte: Optional[Union[str, datetime, date]] = None,
     settlement_date_gt: Optional[Union[str, datetime, date]] = None,
     settlement_date_gte: Optional[Union[str, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -871,7 +871,7 @@ async def list_short_volume(
     date_lte: Optional[Union[str, datetime, date]] = None,
     date_gt: Optional[Union[str, datetime, date]] = None,
     date_gte: Optional[Union[str, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -908,7 +908,7 @@ async def list_treasury_yields(
     date_lte: Optional[Union[str, datetime, date]] = None,
     date_gt: Optional[Union[str, datetime, date]] = None,
     date_gte: Optional[Union[str, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     order: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
@@ -944,7 +944,7 @@ async def list_inflation(
     date_gte: Optional[Union[str, datetime, date]] = None,
     date_lt: Optional[Union[str, datetime, date]] = None,
     date_lte: Optional[Union[str, datetime, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1015,7 +1015,7 @@ async def list_benzinga_analyst_insights(
     benzinga_rating_id_gte: Optional[str] = None,
     benzinga_rating_id_lt: Optional[str] = None,
     benzinga_rating_id_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1104,7 +1104,7 @@ async def list_benzinga_analysts(
     full_name_gte: Optional[str] = None,
     full_name_lt: Optional[str] = None,
     full_name_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1157,7 +1157,7 @@ async def list_benzinga_consensus_ratings(
     date_gte: Optional[Union[str, date]] = None,
     date_lt: Optional[Union[str, date]] = None,
     date_lte: Optional[Union[str, date]] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
@@ -1238,7 +1238,7 @@ async def list_benzinga_earnings(
     fiscal_period_gte: Optional[str] = None,
     fiscal_period_lt: Optional[str] = None,
     fiscal_period_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1321,7 +1321,7 @@ async def list_benzinga_firms(
     benzinga_id_gte: Optional[str] = None,
     benzinga_id_lt: Optional[str] = None,
     benzinga_id_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1392,7 +1392,7 @@ async def list_benzinga_guidance(
     fiscal_period_gte: Optional[str] = None,
     fiscal_period_lt: Optional[str] = None,
     fiscal_period_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1484,7 +1484,7 @@ async def list_benzinga_news(
     author_gte: Optional[str] = None,
     author_lt: Optional[str] = None,
     author_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1588,7 +1588,7 @@ async def list_benzinga_ratings(
     benzinga_firm_id_gte: Optional[str] = None,
     benzinga_firm_id_lt: Optional[str] = None,
     benzinga_firm_id_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1672,7 +1672,7 @@ async def list_futures_aggregates(
     window_start_lte: Optional[str] = None,
     window_start_gt: Optional[str] = None,
     window_start_gte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1708,7 +1708,7 @@ async def list_futures_contracts(
     as_of: Optional[Union[str, date]] = None,
     active: Optional[str] = None,
     type: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1769,7 +1769,7 @@ async def list_futures_products(
     asset_class: Optional[str] = None,
     asset_sub_class: Optional[str] = None,
     type: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1837,7 +1837,7 @@ async def list_futures_quotes(
     session_end_date_lte: Optional[str] = None,
     session_end_date_gt: Optional[str] = None,
     session_end_date_gte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1882,7 +1882,7 @@ async def list_futures_trades(
     session_end_date_lte: Optional[str] = None,
     session_end_date_gt: Optional[str] = None,
     session_end_date_gte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1918,7 +1918,7 @@ async def list_futures_trades(
 async def list_futures_schedules(
     session_end_date: Optional[str] = None,
     trading_venue: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1949,7 +1949,7 @@ async def list_futures_schedules_by_product_code(
     session_end_date_lte: Optional[str] = None,
     session_end_date_gt: Optional[str] = None,
     session_end_date_gte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -1980,7 +1980,7 @@ async def list_futures_schedules_by_product_code(
 async def list_futures_market_statuses(
     product_code_any_of: Optional[str] = None,
     product_code: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -2017,7 +2017,7 @@ async def get_futures_snapshot(
     product_code_gte: Optional[str] = None,
     product_code_lt: Optional[str] = None,
     product_code_lte: Optional[str] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sort: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:


### PR DESCRIPTION
Some API endpoints can have a default of hundreds of results which eats a lot of tokens. The LLMs aren't likely to use the limit param reliably so we should at least set a low default and if the response is insufficient the LLM can issue another request.