### PR TITLE
fix: use relative import for formatters

### DIFF
--- a/src/mcp_polygon/server.py
+++ b/src/mcp_polygon/server.py
@@ -4,7 +4,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from polygon import RESTClient
 from importlib.metadata import version, PackageNotFoundError
-from src.mcp_polygon.formatters import json_to_csv
+from .formatters import json_to_csv
 
 from datetime import datetime, date
 


### PR DESCRIPTION
Quick fix for a relative import error, seemingly introduced in #33 

```
Traceback (most recent call last):
  File "/Users/redacted/.cache/uv/archive-v0/THgpd63DeR44i3tg-_heo/bin/mcp_polygon", line 6, in <module>
    from mcp_polygon import run
  File "/Users/redacted/.cache/uv/archive-v0/THgpd63DeR44i3tg-_heo/lib/python3.13/site-packages/mcp_polygon/__init__.py", line 1, in <module>
    from .server import run
  File "/Users/redacted/.cache/uv/archive-v0/THgpd63DeR44i3tg-_heo/lib/python3.13/site-packages/mcp_polygon/server.py", line 7, in <module>
    from src.mcp_polygon.formatters import json_to_csv
ModuleNotFoundError: No module named 'src'
```