### PR TITLE
Fix windows hatchling build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install the MCP server, then register it with Claude Code:
 
 ```bash
 # Install the server (one-time — downloads dependencies ahead of time)
-uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.8.6"
+uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.8.7"
 
 # Register with Claude Code
 claude mcp add massive -e MASSIVE_API_KEY=your_api_key_here -- mcp_massive
@@ -102,7 +102,7 @@ You can also run `claude mcp add-from-claude-desktop` if the MCP server is insta
 1. Install the server:
 
 ```bash
-uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.8.6"
+uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.8.7"
 ```
 
 3. Find the installed binary path:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcp_massive",
   "display_name": "Massive Market Data",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Stocks, options & indices market data via Massive.com financial data API. Access real-time and historical prices, quotes, trades, and aggregates for equities, options contracts, ETFs, FX, crypto, and more.",
   "author": {
     "name": "Massive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp_massive"
-version = "0.8.6"
+version = "0.8.7"
 description = "A MCP server project"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ name = "Massive"
 email = "support@massive.com"
 
 [build-system]
-requires = [ "hatchling",]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "mcp-massive"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
We've had reports that the hatchling build fails on some windows machines. This PR swaps out the hatchling build for `uv` to consolidate tools and hopefully provide a more reliable setup experience across operating systems.