### PR TITLE
Improve endpoint search rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install the MCP server, then register it with Claude Code:
 
 ```bash
 # Install the server (one-time — downloads dependencies ahead of time)
-uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.9.0"
+uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.9.1"
 
 # Register with Claude Code
 claude mcp add massive -e MASSIVE_API_KEY=your_api_key_here -- mcp_massive
@@ -101,7 +101,7 @@ You can also run `claude mcp add-from-claude-desktop` if the MCP server is insta
 1. Install the server:
 
 ```bash
-uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.9.0"
+uv tool install "mcp_massive @ git+https://github.com/massive-com/mcp_massive@v0.9.1"
 ```
 
 3. Find the installed binary path:

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "mcp_massive",
   "display_name": "Massive Market Data",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Stocks, options & indices market data via Massive.com financial data API. Access real-time and historical prices, quotes, trades, and aggregates for equities, options contracts, ETFs, FX, crypto, and more.",
   "author": {
     "name": "Massive",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp_massive"
-version = "0.9.0"
+version = "0.9.1"
 description = "A MCP server project"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_massive/constants.py
+++ b/src/mcp_massive/constants.py
@@ -8,9 +8,13 @@ _TOKEN_RE = re.compile(r"[a-z0-9]+")
 # in the llms.txt endpoint names/descriptions.
 # Values can be a single string or a list of strings for ambiguous terms.
 ALIASES: dict[str, str | list[str]] = {
-    # aggregates / bars / OHLC
+    # aggregates / bars / OHLC.  Custom Bars titles don't literally
+    # contain "aggregate", so we cross-expand "aggregate(s)" to "bars"
+    # and "ohlc" so queries for "aggregates" still surface them.
     "agg": ["aggregate", "bars", "ohlc"],
     "aggs": ["aggregate", "bars", "ohlc"],
+    "aggregate": ["bars", "ohlc"],
+    "aggregates": ["bars", "ohlc"],
     "candle": ["aggregate", "bars", "ohlc"],
     "candles": ["aggregate", "bars", "ohlc"],
     "candlestick": ["aggregate", "bars", "ohlc"],
@@ -102,7 +106,15 @@ ALIASES: dict[str, str | list[str]] = {
     # filings
     "10k": "filings",
     "sec": "filings",
+    "edgar": "filings",
     "filing": "filings",
+    # ratios (financial)
+    "roe": "ratios",
+    "roa": "ratios",
+    "roic": "ratios",
+    # alternative / consumer spending
+    "mcc": "merchant",
+    "merchants": "merchant",
     # etf
     "etf": "etf",
     # float
@@ -110,6 +122,12 @@ ALIASES: dict[str, str | list[str]] = {
     # labor / employment
     "unemployment": "labor",
     "jobs": "labor",
+    "nonfarm": "labor",
+    "payroll": "labor",
+    "payrolls": "labor",
+    "jobless": "labor",
+    "claims": "labor",
+    "employment": "labor",
     # conversion
     "convert": "conversion",
     # indices
@@ -143,6 +161,7 @@ ALIASES: dict[str, str | list[str]] = {
     "bond": "treasury",
     "bonds": "treasury",
     "cpi": "inflation",
+    "breakeven": "inflation",
     "rate": "treasury",
     "rates": "treasury",
     # market status
@@ -153,14 +172,28 @@ ALIASES: dict[str, str | list[str]] = {
     "exchange": "exchanges",
 }
 
-# Market keywords used to boost endpoints whose market matches the query.
+# Market keywords used to infer the market filter from a free-text query.
+# Only include tokens whose sole/primary meaning is the asset class —
+# polysemous words (e.g. "index") pull the filter onto wrong endpoints.
 _MARKET_KEYWORDS: dict[str, set[str]] = {
     "Stocks": {"stock", "stocks", "equity", "equities", "share", "shares"},
     "Crypto": {"crypto", "cryptocurrency", "bitcoin", "btc", "eth", "coin"},
     "Forex": {"forex", "fx", "currency", "currencies"},
     "Options": {"option", "options", "call", "put", "strike", "chain"},
-    "Futures": {"future", "futures", "futs"},
-    "Indices": {"index", "indices", "benchmark"},
+    "Futures": {
+        "future", "futures", "futs",
+        "commodity", "commodities",
+        "crude", "oil", "gold", "silver", "gas", "wheat", "corn",
+        "cme", "nymex", "cbot",
+    },
+    # NOTE: "index" deliberately omitted — collides with "consumer price
+    # index", "SEC EDGAR index", "filings index", etc. where the user
+    # means a table/document.  Users who mean the asset class typically
+    # say "indices", "benchmark", or a specific index symbol.
+    "Indices": {
+        "indices", "benchmark",
+        "spx", "djia", "dow", "nikkei", "ftse",
+    },
     "Economy": {"economy", "economic", "treasury", "inflation", "yield", "bond"},
 }
 

--- a/src/mcp_massive/index.py
+++ b/src/mcp_massive/index.py
@@ -117,36 +117,99 @@ def _expand_query(query: str) -> str:
     return _to_fts5(terms)
 
 
+def _extract_attr_vocab(ep: "Endpoint") -> list[str]:
+    """Collect domain vocabulary from response-attribute names.
+
+    Query params are intentionally excluded — they're dominated by
+    generic filter operators (``ticker``, ``date``, ``limit``, ``sort``,
+    ``.gt``/``.gte`` variants) that are near-universal across endpoints
+    and add noise without distinguishing power.  Response-attribute
+    names are where the specific jargon lives: ``debt_to_equity``,
+    ``yield_10_year``, ``ask_price``, ``constituent_ticker`` — these
+    are the terms users actually type when they already know the domain.
+
+    Names stay in snake_case; FTS5's tokenizer splits on underscores
+    and punctuation so ``debt_to_equity`` indexes as three searchable
+    tokens.  The common ``results[].``/``results.`` prefix is stripped
+    so only the field name itself is indexed.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for ra in ep.response_attributes:
+        name = ra.name
+        for prefix in ("results[].", "results."):
+            if name.startswith(prefix):
+                name = name[len(prefix) :]
+                break
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return out
+
+
 class EndpointIndex:
-    """BM25-ranked endpoint search backed by SQLite FTS5.
+    """Hybrid endpoint search: ``market`` filter + BM25 FTS5 + soft boost.
 
-    Columns and their ``bm25()`` weights:
-        title (10.0), market (5.0), description (1.0), path_info (0.5)
+    Endpoints live in a single FTS5 virtual table.  ``market`` is an
+    *indexed* column (contributes to BM25 scoring) and also supports
+    ``WHERE market = ?`` for strict filtering when the caller passes
+    an explicit market.  ``market`` comes from the ``## Market``
+    headers in the docs — the one facet reliably derivable without a
+    hand-curated mapping.
 
-    FTS5's built-in porter tokenizer handles stemming at both index and
-    query time, so explicit stemming/stopword removal is unnecessary.
+    Indexed market is the primary mechanism that biases results toward
+    a relevant asset class: a query containing "stock" matches the
+    literal text "Stocks" in the market column of every Stocks-market
+    row, contributing a reliable per-endpoint BM25 signal.  On top of
+    that, when we detect a market keyword we also apply a multiplicative
+    :attr:`_MARKET_BOOST` so the shift is robust across small and large
+    corpora (the market column alone depends on token IDF, which
+    degrades when the same token appears on most rows).
+
+    Explicit ``market`` is a hard filter — only rows with that market
+    are considered, even if the result set is empty.  The CASE boost
+    is skipped in that case since all remaining rows already match.
+
+    Category-level disambiguation within a market is left to BM25 over
+    title/description/path_info/attrs plus the query-time
+    :data:`ALIASES` synonym expansion.  The ``attrs`` column holds
+    response-attribute field names — this is how jargon like
+    ``debt_to_equity``, ``yield_10_year``, or ``ask_price`` surfaces
+    the right endpoint without hand-curated aliases.
     """
 
-    # Column weights passed to bm25(): title, market, description, path_info
-    _WEIGHTS = "10.0, 5.0, 1.0, 0.5"
+    # Column weights for bm25() in declared column order:
+    # title, description, path_info, attrs, market.
+    _WEIGHTS = "10.0, 1.0, 0.5, 0.1, 5.0"
 
-    # Market boost: multiply score by this factor when query mentions a market.
+    # Over-fetch factor: fetch extra rows to compensate for deduplication.
+    # Many endpoints share titles across markets (e.g. "Unified Snapshot"
+    # appears 5 times).  We fetch more than top_k from FTS5 and then keep
+    # only the highest-scoring endpoint per title.
+    _DEDUP_FETCH_FACTOR = 4
+
+    # Soft boost multiplier for inferred-market rows.  SQLite's bm25()
+    # returns non-positive scores (lower = better), so multiplying by
+    # a value > 1 makes matching-market scores *more* negative — they
+    # rank higher, but a strong cross-market BM25 match can still win.
     _MARKET_BOOST = 2.0
 
     def __init__(self, endpoints: list[Endpoint]):
         self._endpoints = endpoints
 
-        # Build FTS5 index in an in-memory SQLite database
         self._conn = sqlite3.connect(":memory:", check_same_thread=False)
         self._conn.execute(
             "CREATE VIRTUAL TABLE ep_fts USING fts5("
-            "  title, market, description, path_info,"
+            "  title, description, path_info, attrs, market,"
             "  tokenize='porter'"
             ")"
         )
 
         for i, ep in enumerate(endpoints):
-            # path_info: camelCase param tokens + meaningful path segments
+            # path_info: camelCase param tokens + meaningful path segments.
+            # Carries path-derived category signals (e.g. "aggs", "trades",
+            # "snapshot") into BM25 so free-text queries against them rank
+            # the right endpoints without a hand-curated category table.
             path_parts: list[str] = []
             for param in re.findall(r"\{(\w+)\}", ep.path):
                 path_parts.extend(re.findall(r"[a-z]+", param))
@@ -160,9 +223,16 @@ class EndpointIndex:
                     path_parts.append(seg)
 
             self._conn.execute(
-                "INSERT INTO ep_fts(rowid, title, market, description, path_info) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (i, ep.title, ep.market, ep.description, " ".join(path_parts)),
+                "INSERT INTO ep_fts(rowid, title, description, "
+                "path_info, attrs, market) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    i,
+                    ep.title,
+                    ep.description,
+                    " ".join(path_parts),
+                    " ".join(_extract_attr_vocab(ep)),
+                    ep.market,
+                ),
             )
 
         # Regex allowlist from path prefixes
@@ -170,13 +240,57 @@ class EndpointIndex:
             re.compile("^" + re.escape(ep.path_prefix)) for ep in endpoints
         ]
 
-    # Over-fetch factor: fetch extra rows to compensate for deduplication.
-    # Many endpoints share titles across markets (e.g. "Unified Snapshot"
-    # appears 5 times).  We fetch more than top_k from FTS5 and then keep
-    # only the highest-scoring endpoint per title.
-    _DEDUP_FETCH_FACTOR = 4
+    def _run_fts(
+        self,
+        fts_query: str,
+        limit: int,
+        market_filter: str | None = None,
+        boost_market: str | None = None,
+    ) -> list[int]:
+        """Execute an FTS MATCH.
 
-    def search(self, query: str, top_k: int = 7) -> list[Endpoint]:
+        ``market_filter`` restricts results via ``WHERE market = ?``
+        (used for the explicit-market parameter — strict).
+
+        ``boost_market`` multiplies the BM25 score by
+        :attr:`_MARKET_BOOST` for rows whose market equals it (used for
+        inferred market — soft preference).  Mutually useful only when
+        ``market_filter`` is ``None``.
+        """
+        # Build SQL and parameters in SQL left-to-right order so the
+        # positional ? placeholders line up with params correctly.
+        score_expr = f"bm25(ep_fts, {self._WEIGHTS})"
+        params: list = [fts_query]
+        where = "ep_fts MATCH ?"
+        if market_filter is not None:
+            where += " AND market = ?"
+            params.append(market_filter)
+        if boost_market is not None:
+            score_expr += " * CASE WHEN market = ? THEN ? ELSE 1.0 END"
+            params.extend([boost_market, self._MARKET_BOOST])
+        params.append(limit)
+        sql = f"SELECT rowid FROM ep_fts WHERE {where} ORDER BY {score_expr} LIMIT ?"
+        try:
+            cursor = self._conn.execute(sql, params)
+            return [row[0] for row in cursor.fetchall()]
+        except sqlite3.OperationalError:
+            return []
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 7,
+        market: str | None = None,
+    ) -> list[Endpoint]:
+        """Hybrid endpoint search.
+
+        Explicit ``market`` is a hard filter — results are restricted
+        to rows matching it, even if the filtered set is empty.  When
+        ``market`` is ``None`` and one is inferred from the query, we
+        apply a multiplicative BM25 boost to matching-market rows via
+        a ``CASE`` expression; this shifts ranking without excluding
+        cross-market strong matches.
+        """
         if not self._endpoints:
             return []
 
@@ -184,33 +298,22 @@ class EndpointIndex:
         if not fts_query:
             return []
 
-        # bm25() returns negative scores (lower = better).  When a market
-        # keyword is detected we multiply matching-market scores by the boost
-        # factor, making them more negative (= ranked higher).  When no market
-        # is detected the CASE always evaluates to 1.0 (no-op).
-        detected_market = _detect_market(query) or ""
+        explicit_filter = market is not None
+        boost_market = None if explicit_filter else _detect_market(query)
 
         fetch_limit = min(top_k * self._DEDUP_FETCH_FACTOR, len(self._endpoints))
+        rowids = self._run_fts(
+            fts_query,
+            fetch_limit,
+            market_filter=market if explicit_filter else None,
+            boost_market=boost_market,
+        )
 
-        try:
-            cursor = self._conn.execute(
-                f"SELECT rowid FROM ep_fts "
-                f"WHERE ep_fts MATCH ? "
-                f"ORDER BY bm25(ep_fts, {self._WEIGHTS}) "
-                f"  * CASE WHEN market = ? THEN ? ELSE 1.0 END "
-                f"LIMIT ?",
-                (fts_query, detected_market, self._MARKET_BOOST, fetch_limit),
-            )
-            rows = cursor.fetchall()
-        except sqlite3.OperationalError:
-            return []
-
-        # Deduplicate: keep only the first (highest-scoring) endpoint per
-        # title.  This prevents cross-market duplicates like 5× "Unified
-        # Snapshot" from consuming all result slots.
+        # Deduplicate by title: keep only the first (highest-scoring) per
+        # title to prevent cross-market duplicates from filling result slots.
         seen_titles: set[str] = set()
         results: list[Endpoint] = []
-        for (rowid,) in rows:
+        for rowid in rowids:
             ep = self._endpoints[rowid]
             if ep.title in seen_titles:
                 continue

--- a/src/mcp_massive/server.py
+++ b/src/mcp_massive/server.py
@@ -226,8 +226,29 @@ async def search_endpoints(
             ),
         ),
     ] = None,
+    market: Annotated[
+        Optional[
+            Literal[
+                "Stocks",
+                "Options",
+                "Crypto",
+                "Forex",
+                "Futures",
+                "Indices",
+                "Economy",
+                "Alternative",
+                "Reference",
+            ]
+        ],
+        Field(
+            description=(
+                "Optional market/asset class filter. Omit to infer from the query. "
+                "Use to pin results to a specific asset class when you already know it."
+            ),
+        ),
+    ] = None,
 ) -> str:
-    """Search for market data API endpoints and built-in finance functions by natural language query. Use this FIRST to find the right endpoint before calling call_api. Covers stocks, options, forex, crypto, futures, indices, ETFs, and economic data. Use detail="more" to see query parameter docs needed for building call_api requests."""
+    """Search for market data API endpoints and built-in finance functions by natural language query. Use this FIRST to find the right endpoint before calling call_api. Covers stocks, options, forex, crypto, futures, indices, ETFs, and economic data. Pass market to pin results to a specific asset class when you already know it; omit it and the server will infer from the query. Use detail="more" to see query parameter docs needed for building call_api requests."""
     effective_detail = detail or "default"
 
     lines = []
@@ -240,7 +261,7 @@ async def search_endpoints(
         idx = await _get_index()
         default_k = 7 if scope == "endpoints" else 5
         top_k = max_results if max_results is not None else default_k
-        results = idx.search(query, top_k=top_k)
+        results = idx.search(query, top_k=top_k, market=market)
         for ep in results:
             lines.append(ep.format(effective_detail, counter))
             counter += 1

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse
 from mcp_massive.index import (
     Endpoint,
     EndpointIndex,
+    QueryParam,
+    ResponseAttribute,
     parse_llms_txt,
     parse_llms_full_txt,
     parse_endpoint_section,
@@ -703,8 +705,342 @@ class TestLlmsFullTxtE2E:
         # Basic search should return results
         results = idx.search("stock aggregate bars")
         assert len(results) > 0
-        assert any("aggregate" in ep.title.lower() for ep in results)
+        # Real endpoint titles use "Bars (OHLC)" naming.  Accept any
+        # aggregates-family marker.
+        assert any(
+            marker in ep.title.lower()
+            for ep in results
+            for marker in ("aggregate", "bars", "ohlc")
+        )
 
         # Market detection should work
         results = idx.search("crypto snapshot")
         assert len(results) > 0
+
+
+class TestMarketFilter:
+    def _endpoints(self):
+        return [
+            Endpoint(
+                title="SMA",
+                path="/v1/indicators/sma/{stocksTicker}",
+                market="Stocks",
+                description="Simple moving average for a stock ticker.",
+                path_prefix="/v1/indicators/sma/",
+            ),
+            Endpoint(
+                title="SMA",
+                path="/v1/indicators/sma/{cryptoTicker}",
+                market="Crypto",
+                description="Simple moving average for a crypto ticker.",
+                path_prefix="/v1/indicators/sma/",
+            ),
+            Endpoint(
+                title="Splits",
+                path="/stocks/v1/splits",
+                market="Stocks",
+                description="Stock split history.",
+                path_prefix="/stocks/v1/splits",
+            ),
+            Endpoint(
+                title="Unified Snapshot",
+                path="/v3/snapshot",
+                market="Stocks",
+                description="Unified snapshot across assets.",
+                path_prefix="/v3/snapshot",
+            ),
+        ]
+
+    def test_explicit_market_is_strict(self):
+        """Explicit market filter excludes all other-market rows."""
+        idx = EndpointIndex(self._endpoints())
+        results = idx.search("sma", market="Crypto")
+        assert all(ep.market == "Crypto" for ep in results)
+        assert results[0].title == "SMA"
+
+    def test_explicit_market_with_zero_matches_returns_empty(self):
+        """Strict mode: no fallback when explicit filter matches nothing."""
+        idx = EndpointIndex(self._endpoints())
+        results = idx.search("sma", market="Forex")
+        assert results == []
+
+    def test_inferred_market_prefers_matching_market(self):
+        """When market is inferred, the matching-market row ranks above
+        a same-titled row from a different market."""
+        idx = EndpointIndex(self._endpoints())
+        results = idx.search("crypto sma")
+        assert results[0].market == "Crypto"
+        assert results[0].title == "SMA"
+
+    def test_empty_endpoints_returns_empty(self):
+        """Regression guard: search over an empty index returns []."""
+        idx = EndpointIndex([])
+        assert idx.search("anything") == []
+        assert idx.search("anything", market="Crypto") == []
+
+    def test_empty_query_returns_empty(self):
+        """A query that tokenizes to nothing short-circuits before FTS."""
+        idx = EndpointIndex(self._endpoints())
+        assert idx.search("") == []
+        assert idx.search("!!!") == []  # only punctuation → no tokens
+
+
+class TestInferredMarketBoost:
+    """Inferred-market preference is a *soft* boost, not a filter:
+
+    1. The ``market`` column is indexed, so its literal value ("Stocks",
+       "Crypto", …) contributes to BM25 whenever the query contains a
+       matching token like "stock" or "crypto".
+    2. When a market is also *detected* from the query via
+       :func:`_detect_market`, we apply a multiplicative
+       :attr:`EndpointIndex._MARKET_BOOST` to all rows whose market
+       matches.
+
+    The combination shifts ranking toward the inferred market but does
+    not hide strong cross-market matches.
+    """
+
+    def _endpoints(self):
+        return [
+            Endpoint(
+                title="Aggregates Stocks",
+                path="/v2/aggs/ticker/{stocksTicker}",
+                market="Stocks",
+                description="Aggregate bars for a stock.",
+                path_prefix="/v2/aggs/ticker/",
+            ),
+            Endpoint(
+                title="Aggregates Crypto",
+                path="/v2/aggs/ticker/{cryptoTicker}",
+                market="Crypto",
+                description="Aggregate bars for crypto.",
+                path_prefix="/v2/aggs/ticker/",
+            ),
+        ]
+
+    def test_cross_market_rows_still_surface(self):
+        """A generic query without a market keyword returns rows from
+        multiple markets — the boost only kicks in when a market is
+        detected, so without one both Stocks and Crypto rows appear."""
+        idx = EndpointIndex(self._endpoints())
+        results = idx.search("aggregates", top_k=5)
+        markets = {ep.market for ep in results}
+        assert "Stocks" in markets
+        assert "Crypto" in markets
+
+    def test_explicit_filter_is_strict(self):
+        """Explicit market filters do NOT apply the boost; only matching
+        rows are returned even when other markets score higher."""
+        idx = EndpointIndex(self._endpoints())
+        results = idx.search("aggregates", market="Stocks", top_k=5)
+        assert all(ep.market == "Stocks" for ep in results)
+
+    def test_unknown_market_endpoint_still_findable(self):
+        """Endpoints whose market matches no detection keywords still
+        surface — we never exclude rows based on inferred market."""
+        endpoints = [
+            Endpoint(
+                title="Mystery Endpoint",
+                path="/some/new/path",
+                market="Partners",
+                description="A novel endpoint under a partner namespace.",
+                path_prefix="/some/new/path",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        results = idx.search("mystery")
+        assert len(results) == 1
+        assert results[0].title == "Mystery Endpoint"
+
+    def test_inferred_market_outranks_other_markets(self):
+        """When the query contains an inferred-market keyword, rows of
+        that market rank above other-market rows."""
+        endpoints = [
+            Endpoint(
+                title="Crypto Aggregates",
+                path="/v2/aggs/ticker/{cryptoTicker}",
+                market="Crypto",
+                description="Aggregate bars for crypto.",
+                path_prefix="/v2/aggs/ticker/",
+            ),
+            Endpoint(
+                title="Crypto Snapshot",
+                path="/v2/snapshot/crypto",
+                market="Crypto",
+                description="Crypto snapshot.",
+                path_prefix="/v2/snapshot/crypto",
+            ),
+            Endpoint(
+                title="Stocks Aggregates",
+                path="/v2/aggs/ticker/{stocksTicker}",
+                market="Stocks",
+                description="Aggregate bars for a stock.",
+                path_prefix="/v2/aggs/ticker/",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        results = idx.search("crypto", top_k=5)
+        crypto_ranks = [i for i, ep in enumerate(results) if ep.market == "Crypto"]
+        stocks_ranks = [i for i, ep in enumerate(results) if ep.market == "Stocks"]
+        assert crypto_ranks, "expected at least one Crypto result"
+        if stocks_ranks:
+            assert max(crypto_ranks) < min(stocks_ranks), (
+                "Crypto rows should all rank above Stocks rows under "
+                "inferred Crypto market: "
+                f"{[(ep.title, ep.market) for ep in results]}"
+            )
+
+    def test_cross_market_title_match_beats_inferred_boost(self):
+        """The boost must not be so large that a weak in-market match
+        outranks a strong cross-market title match.
+
+        Real-world case: "stock ratings" infers Stocks but the right
+        endpoint is Analyst Ratings under Partners — its title match
+        should outweigh the 2x boost any generic Stocks row gets.
+        """
+        endpoints = [
+            Endpoint(
+                title="Splits",
+                path="/stocks/v1/splits",
+                market="Stocks",
+                description="Stock split history.",
+                path_prefix="/stocks/v1/splits",
+            ),
+            Endpoint(
+                title="Trades",
+                path="/v3/trades/{stockTicker}",
+                market="Stocks",
+                description="Historical trades for a stock.",
+                path_prefix="/v3/trades/",
+            ),
+            Endpoint(
+                title="Analyst Ratings",
+                path="/benzinga/v1/ratings",
+                market="Partners",
+                description="Historical analyst ratings and price targets.",
+                path_prefix="/benzinga/v1/ratings",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        results = idx.search("stock ratings", top_k=3)
+        # Partners-market Analyst Ratings should win despite the
+        # inferred-Stocks boost applied to the other two rows.
+        assert results[0].title == "Analyst Ratings"
+        assert results[0].market == "Partners"
+
+
+class TestAttrsColumn:
+    """The ``attrs`` FTS column indexes response-attribute field names
+    (e.g. ``debt_to_equity``, ``yield_10_year``) so queries for those
+    jargon terms surface the right endpoint without hand-curated
+    aliases.  Attrs is weighted well below title/description so it
+    only influences ranking for otherwise-weak matches.
+    """
+
+    def test_response_attr_names_are_indexed(self):
+        """A query matching only a response-attribute field name still
+        finds the endpoint that owns that field."""
+        endpoints = [
+            Endpoint(
+                title="Ratios",
+                path="/stocks/financials/v1/ratios",
+                market="Stocks",
+                description="Key financial ratios for a company.",
+                response_attributes=[
+                    ResponseAttribute(
+                        name="results[].debt_to_equity",
+                        type="number",
+                        description="Debt-to-equity ratio.",
+                    ),
+                    ResponseAttribute(
+                        name="results[].return_on_equity",
+                        type="number",
+                        description="Return on equity.",
+                    ),
+                ],
+                path_prefix="/stocks/financials/v1/ratios",
+            ),
+            Endpoint(
+                title="Last Trade",
+                path="/v2/last/trade/{stocksTicker}",
+                market="Stocks",
+                description="Most recent stock trade.",
+                path_prefix="/v2/last/trade/",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        # "debt_to_equity" appears only in the Ratios endpoint's
+        # response attrs — it should rank Ratios first.
+        results = idx.search("debt to equity", top_k=2)
+        assert results[0].title == "Ratios"
+
+    def test_results_prefix_stripped_from_attrs(self):
+        """The common ``results[].`` / ``results.`` wrapper is stripped
+        so searches don't need to include it."""
+        endpoints = [
+            Endpoint(
+                title="Treasury Yields",
+                path="/fed/v1/treasury-yields",
+                market="Economy",
+                description="U.S. Treasury yield data.",
+                response_attributes=[
+                    ResponseAttribute(
+                        name="results[].yield_10_year",
+                        type="number",
+                        description="",
+                    ),
+                    ResponseAttribute(
+                        name="results[].yield_2_year",
+                        type="number",
+                        description="",
+                    ),
+                ],
+                path_prefix="/fed/v1/treasury-yields",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        # Plain "yield" should find this endpoint via the stripped attrs.
+        results = idx.search("10 year yield")
+        assert results and results[0].title == "Treasury Yields"
+
+    def test_query_params_not_indexed_in_attrs(self):
+        """Query params are NOT added to ``attrs`` — they're dominated
+        by generic filter operators (``ticker``, ``date``, ``limit``,
+        ``sort``) that appear on nearly every endpoint."""
+        endpoints = [
+            Endpoint(
+                title="Trades",
+                path="/v3/trades/{ticker}",
+                market="Stocks",
+                description="Historical trades.",
+                query_params=[
+                    QueryParam(
+                        name="limit",
+                        type="integer",
+                        required=False,
+                        description="",
+                    ),
+                ],
+                path_prefix="/v3/trades/",
+            ),
+            Endpoint(
+                title="Quotes",
+                path="/v3/quotes/{ticker}",
+                market="Stocks",
+                description="Historical quotes.",
+                query_params=[
+                    QueryParam(
+                        name="limit",
+                        type="integer",
+                        required=False,
+                        description="",
+                    ),
+                ],
+                path_prefix="/v3/quotes/",
+            ),
+        ]
+        idx = EndpointIndex(endpoints)
+        # If "limit" were in attrs, this query would match both
+        # endpoints via the attrs column.  We expect no matches.
+        results = idx.search("limit")
+        assert results == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ def _make_test_index():
         Endpoint(
             title="Aggregates Bars",
             path="/v2/aggs/ticker/{stocksTicker}/range/{multiplier}/{timespan}/{from}/{to}",
-            market="Market Data",
+            market="Stocks",
             description="Get aggregate bars for a stock",
             query_params=[
                 QueryParam(
@@ -40,7 +40,7 @@ def _make_test_index():
         Endpoint(
             title="Tickers",
             path="/v3/reference/tickers",
-            market="Reference Data",
+            market="Reference",
             description="Query all ticker symbols",
             query_params=[
                 QueryParam(
@@ -55,9 +55,16 @@ def _make_test_index():
         Endpoint(
             title="Last Trade",
             path="/v2/last/trade/{stocksTicker}",
-            market="Market Data",
+            market="Stocks",
             description="Get the most recent trade for a ticker",
             path_prefix="/v2/last/trade/",
+        ),
+        Endpoint(
+            title="Aggregates Bars Crypto",
+            path="/v2/aggs/ticker/{cryptoTicker}/range/{multiplier}/{timespan}/{from}/{to}",
+            market="Crypto",
+            description="Get aggregate bars for a crypto pair",
+            path_prefix="/v2/aggs/ticker/",
         ),
     ]
     return EndpointIndex(endpoints)
@@ -101,7 +108,7 @@ class TestSearchEndpoints:
     async def test_detail_default(self):
         result = await search_endpoints("aggregate bars")
         assert "Aggregates" in result
-        assert "Market Data" in result
+        assert "Stocks" in result
         assert "/v2/aggs/ticker/" in result
         assert "Query Parameters:" not in result
 
@@ -118,6 +125,12 @@ class TestSearchEndpoints:
         result = await search_endpoints("aggregate bars", detail="verbose")
         assert "Aggregates" in result
         assert "Query Parameters:" in result
+
+    @pytest.mark.asyncio
+    async def test_market_filter_excludes_other_markets(self):
+        result = await search_endpoints("aggregate bars", market="Crypto")
+        assert "[Crypto]" in result
+        assert "[Stocks]" not in result
 
 
 class TestCallApi:

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "mcp-massive"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
Improve search_endpoints quality. The original goal was to add a structured market filter; along the way we also tightened the ranking mechanism, indexed more of the already-parsed doc data, and expanded the query-token alias table then
measured against a 358-query evaluation harness that covers both mainstream traffic and long-tail partner/economy/indices endpoints.

Net result vs master: +9 hit@1, +3 hit@3, +8 hit@7, -8 complete misses. No impactful regressions (15 minor rank shifts within the top 3, all between sibling endpoints).

Changes

- Structured market parameter on search_endpoints (Stocks | Options | Crypto | Forex | Futures | Indices | Economy | Alternative | Reference). Explicit values are a hard WHERE market = ? filter. Omitted → inferred from the query as before.
- market stays as an indexed FTS column (not UNINDEXED) so its value ("Stocks", "Crypto", …) contributes to BM25. Combined with the multiplicative CASE WHEN market = ? THEN 2.0 ELSE 1.0 boost when a market is detected, inferred-market
preference is robust across corpus sizes and doesn't hide strong cross-market matches (e.g. "stock ratings" still returns Analyst Ratings under Partners).
- New attrs FTS column (weight 0.1) that indexes response-attribute field names like debt_to_equity, yield_10_year, ask_price. Zero extra network, ~200 KB extra FTS text, and it fixes a long list of jargon queries without hand-curated
aliases. Query-param names are intentionally excluded (dominated by generic filter operators like ticker/date/limit).
- Expanded ALIASES and _MARKET_KEYWORDS: labor/employment (nonfarm, jobless, claims), inflation (breakeven), filings (edgar), ratios (roe, roa, roic), merchant (mcc), commodity root keywords (crude, oil, gold, cme, …), index symbols (spx,
djia, dow). Dropped index from Indices keywords — it was misrouting queries like "consumer price index" and "SEC EDGAR index". Also cross-expanded aggregate(s) ↔ bars / ohlc so "aggregates" queries find Custom Bars titles.
- Title-based dedup kept — plus over-fetch factor stays at 4× top_k to compensate for cross-market title collisions (e.g. 5× "Unified Snapshot").

Test plan

- uv run pytest tests/ — 661 pass (up from 645 on master; 16 new tests)
- New TestInferredMarketBoost covers the CASE-boost mechanism, including the regression-guard test_cross_market_title_match_beats_inferred_boost that pins down the "stock ratings" → Analyst Ratings case
- New TestAttrsColumn covers response-attribute indexing, the results[]. prefix strip, and that query-param names are not in the attrs column
- Manual spot-check: search_endpoints("aggregate bars", market="Crypto"), search_endpoints("ROE"), search_endpoints("debt to equity"), search_endpoints("stock ratings"), search_endpoints("ETF categories") all return the expected endpoint at rank 1 or 2.