### PR TITLE
Add vanna and volga functions

### DIFF
--- a/src/mcp_massive/constants.py
+++ b/src/mcp_massive/constants.py
@@ -90,6 +90,9 @@ ALIASES: dict[str, str | list[str]] = {
     "theta": ["bs_theta", "options"],
     "vega": ["bs_vega", "options"],
     "rho": ["bs_rho", "options"],
+    "vanna": ["bs_vanna", "options"],
+    "volga": ["bs_volga", "options"],
+    "vomma": ["bs_volga", "options"],
     "blackscholes": ["bs_price", "bs_delta"],
     # technical indicators
     "sma": "aggregate",
@@ -181,18 +184,34 @@ _MARKET_KEYWORDS: dict[str, set[str]] = {
     "Forex": {"forex", "fx", "currency", "currencies"},
     "Options": {"option", "options", "call", "put", "strike", "chain"},
     "Futures": {
-        "future", "futures", "futs",
-        "commodity", "commodities",
-        "crude", "oil", "gold", "silver", "gas", "wheat", "corn",
-        "cme", "nymex", "cbot",
+        "future",
+        "futures",
+        "futs",
+        "commodity",
+        "commodities",
+        "crude",
+        "oil",
+        "gold",
+        "silver",
+        "gas",
+        "wheat",
+        "corn",
+        "cme",
+        "nymex",
+        "cbot",
     },
     # NOTE: "index" deliberately omitted — collides with "consumer price
     # index", "SEC EDGAR index", "filings index", etc. where the user
     # means a table/document.  Users who mean the asset class typically
     # say "indices", "benchmark", or a specific index symbol.
     "Indices": {
-        "indices", "benchmark",
-        "spx", "djia", "dow", "nikkei", "ftse",
+        "indices",
+        "benchmark",
+        "spx",
+        "djia",
+        "dow",
+        "nikkei",
+        "ftse",
     },
     "Economy": {"economy", "economic", "treasury", "inflation", "yield", "bond"},
 }

--- a/src/mcp_massive/constants.py
+++ b/src/mcp_massive/constants.py
@@ -93,6 +93,9 @@ ALIASES: dict[str, str | list[str]] = {
     "vanna": ["bs_vanna", "options"],
     "volga": ["bs_volga", "options"],
     "vomma": ["bs_volga", "options"],
+    "charm": ["bs_charm", "options"],
+    "veta": ["bs_veta", "options"],
+    "color": ["bs_color", "options"],
     "blackscholes": ["bs_price", "bs_delta"],
     # technical indicators
     "sma": "aggregate",

--- a/src/mcp_massive/functions.py
+++ b/src/mcp_massive/functions.py
@@ -308,6 +308,35 @@ def _impl_bs_rho(table: Table, inputs: dict[str, Any]) -> np.ndarray:
     return rho / 100.0
 
 
+def _impl_bs_vanna(table: Table, inputs: dict[str, Any]) -> np.ndarray:
+    n = len(table)
+    S = _to_numpy(inputs["S"], n)
+    K = _to_numpy(inputs["K"], n)
+    T = _to_numpy(inputs["T"], n)
+    r = _to_numpy(inputs["r"], n)
+    sigma = _to_numpy(inputs["sigma"], n)
+
+    d1, d2 = _bs_d1d2(S, K, T, r, sigma)
+    vanna = -_norm_pdf(d1) * d2 / sigma
+    # Per 1% change in volatility (matches bs_vega scaling)
+    return vanna / 100.0
+
+
+def _impl_bs_volga(table: Table, inputs: dict[str, Any]) -> np.ndarray:
+    n = len(table)
+    S = _to_numpy(inputs["S"], n)
+    K = _to_numpy(inputs["K"], n)
+    T = _to_numpy(inputs["T"], n)
+    r = _to_numpy(inputs["r"], n)
+    sigma = _to_numpy(inputs["sigma"], n)
+
+    d1, d2 = _bs_d1d2(S, K, T, r, sigma)
+    vega = S * _norm_pdf(d1) * np.sqrt(T)
+    volga = vega * d1 * d2 / sigma
+    # Per (1% vol)^2 — change in bs_vega per 1% vol change
+    return volga / 10000.0
+
+
 # ---------------------------------------------------------------------------
 # Returns implementations (numpy)
 # ---------------------------------------------------------------------------
@@ -573,6 +602,28 @@ _register(
         params=[*_BS_COMMON_PARAMS, _BS_OPTION_TYPE_PARAM],
         output_dtype="Float64",
         impl=_impl_bs_rho,
+    )
+)
+
+_register(
+    FunctionDef(
+        name="bs_vanna",
+        category="Greeks",
+        description="Black-Scholes vanna (dDelta/dSigma = dVega/dSpot) per 1% change in volatility. Same for calls and puts.",
+        params=list(_BS_COMMON_PARAMS),
+        output_dtype="Float64",
+        impl=_impl_bs_vanna,
+    )
+)
+
+_register(
+    FunctionDef(
+        name="bs_volga",
+        category="Greeks",
+        description="Black-Scholes volga / vomma. Change in bs_vega per 1% volatility change. Same for calls and puts.",
+        params=list(_BS_COMMON_PARAMS),
+        output_dtype="Float64",
+        impl=_impl_bs_volga,
     )
 )
 

--- a/src/mcp_massive/functions.py
+++ b/src/mcp_massive/functions.py
@@ -205,18 +205,30 @@ def _bs_d1d2(
     return d1, d2
 
 
+def _bs_inputs(
+    inputs: dict[str, Any], n: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Resolve the five common BS params (S, K, T, r, sigma) to numpy arrays.
+
+    apply_pipeline guarantees these keys are present before the impl runs;
+    no defensive checks needed here.
+    """
+    return (
+        _to_numpy(inputs["S"], n),
+        _to_numpy(inputs["K"], n),
+        _to_numpy(inputs["T"], n),
+        _to_numpy(inputs["r"], n),
+        _to_numpy(inputs["sigma"], n),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Greeks implementations
 # ---------------------------------------------------------------------------
 
 
 def _impl_bs_price(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
     option_type = _validate_option_type(inputs)
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
@@ -228,12 +240,7 @@ def _impl_bs_price(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_delta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
     option_type = _validate_option_type(inputs)
 
     d1, _d2 = _bs_d1d2(S, K, T, r, sigma)
@@ -245,12 +252,7 @@ def _impl_bs_delta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_gamma(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, _d2 = _bs_d1d2(S, K, T, r, sigma)
     gamma = _norm_pdf(d1) / (S * sigma * np.sqrt(T))
@@ -258,12 +260,7 @@ def _impl_bs_gamma(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_theta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
     option_type = _validate_option_type(inputs)
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
@@ -277,12 +274,7 @@ def _impl_bs_theta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_vega(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, _d2 = _bs_d1d2(S, K, T, r, sigma)
     vega = S * _norm_pdf(d1) * np.sqrt(T)
@@ -291,12 +283,7 @@ def _impl_bs_vega(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_rho(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
     option_type = _validate_option_type(inputs)
 
     _d1, d2 = _bs_d1d2(S, K, T, r, sigma)
@@ -309,12 +296,7 @@ def _impl_bs_rho(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_vanna(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
     vanna = -_norm_pdf(d1) * d2 / sigma
@@ -323,12 +305,7 @@ def _impl_bs_vanna(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_volga(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
     vega = S * _norm_pdf(d1) * np.sqrt(T)
@@ -344,12 +321,7 @@ def _impl_bs_volga(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_charm(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
     sqrt_T = np.sqrt(T)
@@ -361,12 +333,7 @@ def _impl_bs_charm(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_veta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
     sqrt_T = np.sqrt(T)
@@ -381,12 +348,7 @@ def _impl_bs_veta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
 
 
 def _impl_bs_color(table: Table, inputs: dict[str, Any]) -> np.ndarray:
-    n = len(table)
-    S = _to_numpy(inputs["S"], n)
-    K = _to_numpy(inputs["K"], n)
-    T = _to_numpy(inputs["T"], n)
-    r = _to_numpy(inputs["r"], n)
-    sigma = _to_numpy(inputs["sigma"], n)
+    S, K, T, r, sigma = _bs_inputs(inputs, len(table))
 
     d1, d2 = _bs_d1d2(S, K, T, r, sigma)
     sqrt_T = np.sqrt(T)

--- a/src/mcp_massive/functions.py
+++ b/src/mcp_massive/functions.py
@@ -337,6 +337,68 @@ def _impl_bs_volga(table: Table, inputs: dict[str, Any]) -> np.ndarray:
     return volga / 10000.0
 
 
+# Calendar-time time-decay Greeks: ∂x/∂t (bleeds with passage of time).
+# Same sign convention as bs_theta — negative for the long-option holder
+# in the typical ATM case.  Assumes no dividends (q=0); under that
+# assumption charm/veta/color are identical for calls and puts.
+
+
+def _impl_bs_charm(table: Table, inputs: dict[str, Any]) -> np.ndarray:
+    n = len(table)
+    S = _to_numpy(inputs["S"], n)
+    K = _to_numpy(inputs["K"], n)
+    T = _to_numpy(inputs["T"], n)
+    r = _to_numpy(inputs["r"], n)
+    sigma = _to_numpy(inputs["sigma"], n)
+
+    d1, d2 = _bs_d1d2(S, K, T, r, sigma)
+    sqrt_T = np.sqrt(T)
+    charm = (
+        -_norm_pdf(d1) * (2 * r * T - d2 * sigma * sqrt_T) / (2 * T * sigma * sqrt_T)
+    )
+    # Per day (matches bs_theta /365 convention)
+    return charm / 365.0
+
+
+def _impl_bs_veta(table: Table, inputs: dict[str, Any]) -> np.ndarray:
+    n = len(table)
+    S = _to_numpy(inputs["S"], n)
+    K = _to_numpy(inputs["K"], n)
+    T = _to_numpy(inputs["T"], n)
+    r = _to_numpy(inputs["r"], n)
+    sigma = _to_numpy(inputs["sigma"], n)
+
+    d1, d2 = _bs_d1d2(S, K, T, r, sigma)
+    sqrt_T = np.sqrt(T)
+    veta = (
+        S
+        * _norm_pdf(d1)
+        * sqrt_T
+        * (r * d1 / (sigma * sqrt_T) - (1.0 + d1 * d2) / (2.0 * T))
+    )
+    # Per day, per 1% vol — change in bs_vega per day
+    return veta / 36500.0
+
+
+def _impl_bs_color(table: Table, inputs: dict[str, Any]) -> np.ndarray:
+    n = len(table)
+    S = _to_numpy(inputs["S"], n)
+    K = _to_numpy(inputs["K"], n)
+    T = _to_numpy(inputs["T"], n)
+    r = _to_numpy(inputs["r"], n)
+    sigma = _to_numpy(inputs["sigma"], n)
+
+    d1, d2 = _bs_d1d2(S, K, T, r, sigma)
+    sqrt_T = np.sqrt(T)
+    color = (
+        _norm_pdf(d1)
+        / (2.0 * S * T * sigma * sqrt_T)
+        * (1.0 + (2.0 * r * T - d2 * sigma * sqrt_T) * d1 / (sigma * sqrt_T))
+    )
+    # Per day — change in bs_gamma per day
+    return color / 365.0
+
+
 # ---------------------------------------------------------------------------
 # Returns implementations (numpy)
 # ---------------------------------------------------------------------------
@@ -576,7 +638,7 @@ _register(
     FunctionDef(
         name="bs_theta",
         category="Greeks",
-        description="Black-Scholes daily theta (annual theta / 365).",
+        description="Black-Scholes daily theta. Time decay — change in option price per day (annual theta / 365).",
         params=[*_BS_COMMON_PARAMS, _BS_OPTION_TYPE_PARAM],
         output_dtype="Float64",
         impl=_impl_bs_theta,
@@ -624,6 +686,39 @@ _register(
         params=list(_BS_COMMON_PARAMS),
         output_dtype="Float64",
         impl=_impl_bs_volga,
+    )
+)
+
+_register(
+    FunctionDef(
+        name="bs_charm",
+        category="Greeks",
+        description="Black-Scholes charm (delta decay). Change in bs_delta per day. Assumes no dividends; same for calls and puts under that assumption.",
+        params=list(_BS_COMMON_PARAMS),
+        output_dtype="Float64",
+        impl=_impl_bs_charm,
+    )
+)
+
+_register(
+    FunctionDef(
+        name="bs_veta",
+        category="Greeks",
+        description="Black-Scholes veta / DvegaDtime (vega decay). Change in bs_vega per day. Assumes no dividends; same for calls and puts under that assumption.",
+        params=list(_BS_COMMON_PARAMS),
+        output_dtype="Float64",
+        impl=_impl_bs_veta,
+    )
+)
+
+_register(
+    FunctionDef(
+        name="bs_color",
+        category="Greeks",
+        description="Black-Scholes color (gamma decay). Change in bs_gamma per day. Assumes no dividends; same for calls and puts under that assumption.",
+        params=list(_BS_COMMON_PARAMS),
+        output_dtype="Float64",
+        impl=_impl_bs_color,
     )
 )
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -235,6 +235,31 @@ class TestBlackScholesGreeks:
         assert 0.01 < gamma < 0.03
         assert abs(gamma - 0.018762017345846895) < 0.001
 
+    def test_bs_gamma_otm(self):
+        # OTM call S=80, K=100, T=1, r=0.05, sigma=0.2 → d1=-0.7657, d2=-0.9657.
+        # Gamma is always positive but the magnitude moves; verify the formula
+        # away from the at-the-money peak.
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_gamma",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "gamma",
+                }
+            ],
+        )
+        gamma = result["gamma"][0]
+        assert gamma > 0
+        assert abs(gamma - 0.018598225671687875) < 1e-6
+
     def test_bs_theta_call(self, bs_df):
         result = apply_pipeline(
             bs_df,
@@ -279,6 +304,31 @@ class TestBlackScholesGreeks:
         # Vega per 1% vol change ≈ 0.37524
         assert vega > 0
         assert abs(vega - 0.3752403469169379) < 0.01
+
+    def test_bs_vega_otm(self):
+        # OTM call S=80, K=100, T=1, r=0.05, sigma=0.2.
+        # Vega is always positive but smaller off the at-the-money peak;
+        # verify the formula at a non-ATM strike.
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_vega",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "vega",
+                }
+            ],
+        )
+        vega = result["vega"][0]
+        assert vega > 0
+        assert abs(vega - 0.23805728859760478) < 1e-6
 
     def test_bs_rho_call(self, bs_df):
         result = apply_pipeline(
@@ -325,6 +375,77 @@ class TestBlackScholesGreeks:
         # Put rho per 1% rate change ≈ -0.41890
         assert rho < 0
         assert abs(rho - (-0.4189046090469506)) < 0.01
+
+    def test_bs_vanna(self, bs_df):
+        result = apply_pipeline(
+            bs_df,
+            [
+                {
+                    "function": "bs_vanna",
+                    "inputs": {
+                        "S": "S",
+                        "K": "K",
+                        "T": "T",
+                        "r": "r",
+                        "sigma": "sigma",
+                    },
+                    "output": "vanna",
+                }
+            ],
+        )
+        vanna = result["vanna"][0]
+        # vanna_raw = -phi(d1) * d2 / sigma; per 1% vol → /100
+        # phi(0.35) ≈ 0.375240 → vanna_/100 ≈ -0.0028143
+        assert vanna < 0
+        assert abs(vanna - (-0.002814302601877034)) < 1e-5
+
+    def test_bs_vanna_sign_flip(self):
+        # vanna sign tracks -d2.  At ATM (d2 > 0) vanna is negative; at OTM
+        # call S=80, K=100 (d2 = -0.9657 < 0) it flips positive.  This
+        # catches sign errors the at-the-money case can't.
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_vanna",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "vanna",
+                }
+            ],
+        )
+        vanna = result["vanna"][0]
+        assert vanna > 0
+        assert abs(vanna - 0.014368509417491595) < 1e-5
+
+    def test_bs_volga(self, bs_df):
+        result = apply_pipeline(
+            bs_df,
+            [
+                {
+                    "function": "bs_volga",
+                    "inputs": {
+                        "S": "S",
+                        "K": "K",
+                        "T": "T",
+                        "r": "r",
+                        "sigma": "sigma",
+                    },
+                    "output": "volga",
+                }
+            ],
+        )
+        volga = result["volga"][0]
+        # volga_raw = vega_raw * d1 * d2 / sigma; per (1% vol)^2 → /10000
+        # ATM-ish but d1·d2 > 0 so volga > 0; ≈ 0.0009850
+        assert volga > 0
+        assert abs(volga - 0.0009850059106569621) < 1e-6
 
     def test_invalid_option_type(self, bs_df):
         """Invalid option_type should raise ValueError."""
@@ -819,6 +940,8 @@ class TestFunctionRegistry:
             "bs_theta",
             "bs_vega",
             "bs_rho",
+            "bs_vanna",
+            "bs_volga",
             "simple_return",
             "log_return",
             "cumulative_return",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -447,6 +447,142 @@ class TestBlackScholesGreeks:
         assert volga > 0
         assert abs(volga - 0.0009850059106569621) < 1e-6
 
+    def test_bs_charm(self, bs_df):
+        result = apply_pipeline(
+            bs_df,
+            [
+                {
+                    "function": "bs_charm",
+                    "inputs": {
+                        "S": "S",
+                        "K": "K",
+                        "T": "T",
+                        "r": "r",
+                        "sigma": "sigma",
+                    },
+                    "output": "charm",
+                }
+            ],
+        )
+        charm = result["charm"][0]
+        # ATM call delta drifts down with time → charm < 0; ≈ -0.0001799/day
+        assert charm < 0
+        assert abs(charm - (-0.0001799097553711346)) < 1e-8
+
+    def test_bs_charm_otm(self):
+        # OTM call S=80, K=100, T=1, r=0.05, sigma=0.2.
+        # Charm magnitude is larger off-the-money; verify formula away from ATM.
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_charm",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "charm",
+                }
+            ],
+        )
+        charm = result["charm"][0]
+        assert charm < 0
+        assert abs(charm - (-0.0005974739640045683)) < 1e-8
+
+    def test_bs_veta(self, bs_df):
+        result = apply_pipeline(
+            bs_df,
+            [
+                {
+                    "function": "bs_veta",
+                    "inputs": {
+                        "S": "S",
+                        "K": "K",
+                        "T": "T",
+                        "r": "r",
+                        "sigma": "sigma",
+                    },
+                    "output": "veta",
+                }
+            ],
+        )
+        veta = result["veta"][0]
+        # Vega bleeds with time for ATM → veta < 0; ≈ -0.0004511 (Δbs_vega/day)
+        assert veta < 0
+        assert abs(veta - (-0.0004510594581090589)) < 1e-8
+
+    def test_bs_veta_otm(self):
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_veta",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "veta",
+                }
+            ],
+        )
+        veta = result["veta"][0]
+        assert veta < 0
+        assert abs(veta - (-0.000692103013452991)) < 1e-8
+
+    def test_bs_color(self, bs_df):
+        result = apply_pipeline(
+            bs_df,
+            [
+                {
+                    "function": "bs_color",
+                    "inputs": {
+                        "S": "S",
+                        "K": "K",
+                        "T": "T",
+                        "r": "r",
+                        "sigma": "sigma",
+                    },
+                    "output": "color",
+                }
+            ],
+        )
+        color = result["color"][0]
+        # ATM gamma builds with time → color > 0; ≈ +2.885e-5 (Δbs_gamma/day)
+        assert color > 0
+        assert abs(color - 2.884981434344266e-05) < 1e-9
+
+    def test_bs_color_sign_flip(self):
+        # color sign tracks ATM-ness: ATM gamma builds (color > 0) but OTM
+        # gamma decays (color < 0).  Catches sign errors the ATM case can't.
+        df = _table(dummy=[1.0])
+        result = apply_pipeline(
+            df,
+            [
+                {
+                    "function": "bs_color",
+                    "inputs": {
+                        "S": 80.0,
+                        "K": 100.0,
+                        "T": 1.0,
+                        "r": 0.05,
+                        "sigma": 0.2,
+                    },
+                    "output": "color",
+                }
+            ],
+        )
+        color = result["color"][0]
+        assert color < 0
+        assert abs(color - (-3.116504989883754e-06)) < 1e-9
+
     def test_invalid_option_type(self, bs_df):
         """Invalid option_type should raise ValueError."""
         with pytest.raises(ValueError, match="Invalid option_type"):
@@ -942,6 +1078,9 @@ class TestFunctionRegistry:
             "bs_rho",
             "bs_vanna",
             "bs_volga",
+            "bs_charm",
+            "bs_veta",
+            "bs_color",
             "simple_return",
             "log_return",
             "cumulative_return",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -524,6 +524,20 @@ class TestFinanceAliases:
         q = _expand_query("rho")
         assert "bs_rho" in q
 
+    def test_vanna_alias(self):
+        q = _expand_query("vanna")
+        assert "bs_vanna" in q
+        assert "options" in q
+
+    def test_volga_alias(self):
+        q = _expand_query("volga")
+        assert "bs_volga" in q
+        assert "options" in q
+
+    def test_vomma_alias(self):
+        q = _expand_query("vomma")
+        assert "bs_volga" in q
+
     def test_blackscholes_alias(self):
         q = _expand_query("blackscholes")
         assert "bs_price" in q

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -538,6 +538,21 @@ class TestFinanceAliases:
         q = _expand_query("vomma")
         assert "bs_volga" in q
 
+    def test_charm_alias(self):
+        q = _expand_query("charm")
+        assert "bs_charm" in q
+        assert "options" in q
+
+    def test_veta_alias(self):
+        q = _expand_query("veta")
+        assert "bs_veta" in q
+        assert "options" in q
+
+    def test_color_alias(self):
+        q = _expand_query("color")
+        assert "bs_color" in q
+        assert "options" in q
+
     def test_blackscholes_alias(self):
         q = _expand_query("blackscholes")
         assert "bs_price" in q


### PR DESCRIPTION
Closes https://github.com/massive-com/mcp_massive/issues/89

Add second-order Black-Scholes Greeks (vanna, volga, charm, veta, color)

Adds five second-order Greeks to the apply-pipeline registry, alongside aliases for natural-language search:
- bs_vanna — ∂Δ/∂σ = ∂Vega/∂Spot. Sign tracks -d2.
- bs_volga (a.k.a. vomma) — ∂Vega/∂σ. Sign tracks d1·d2.
- bs_charm — ∂Δ/∂t, delta decay. The natural completion of the time/space cross-derivatives now that vanna and volga cover space/vol and vol/vol.
- bs_veta — ∂Vega/∂t, vega decay. Useful for vol-trading P&L attribution.
- bs_color — ∂Γ/∂t, gamma decay. Sign flips between ATM (gamma builds) and OTM (gamma decays).
- Search aliases: vanna, volga, vomma, charm, veta, color.

Implementation nuances

- Calendar-time convention. All time-decay Greeks use ∂x/∂t (not ∂x/∂T), matching the existing bs_theta sign — negative for the long-option holder in the typical ATM case. Wikipedia's published formulas are inconsistent here (some are
labeled ∂x/∂t but evaluate to ∂x/∂T)
- Trader-quoted scaling, consistent with existing Greeks.
  - bs_vanna /= 100 — change in bs_delta per 1% vol.
  - bs_volga /= 10000 — change in bs_vega per 1% vol.
  - bs_charm /= 365 — change in bs_delta per day.
  - bs_veta /= 36500 — change in bs_vega per day.
  - bs_color /= 365 — change in bs_gamma per day.
- No dividends → no option_type. Under the codebase's q=0 assumption, vanna/volga/charm/veta/color are identical for calls and puts (the e^(-qT) call-put difference becomes T-independent). Documented in each description; consistent with how bs_gamma/bs_vega already handle it.
- bs_theta description updated to include the phrase "Time decay" so the canonical time-decay Greek isn't crowded out of the function search by the new charm/veta/color descriptions.